### PR TITLE
remove codesponsor

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,7 @@ Ruby On Rails Apps. :construction: :penguin:
 [![Code Climate](https://codeclimate.com/github/tigefa/tigefa/badges/gpa.svg)](https://codeclimate.com/github/tigefa/tigefa)
 [![security](https://hakiri.io/github/tigefa/tigefa/master.svg)](https://hakiri.io/github/tigefa/tigefa/master)
 
-<a target='_blank' rel='nofollow' href='https://app.codesponsor.io/link/BTZLU3yi9JoCAfUGx1Ca5hea/tigefa/tigefa'>
-  <img alt='Sponsor' width='888' height='68' src='https://app.codesponsor.io/embed/BTZLU3yi9JoCAfUGx1Ca5hea/tigefa/tigefa.svg' />
-</a>
+
 
 ## Plans
 


### PR DESCRIPTION
Pull request automatically sent by knewzen <https://github.com/knewzen>. Because Code Sponsor is shutting down on December 8